### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Builder.yml
+++ b/.github/workflows/Builder.yml
@@ -38,6 +38,8 @@ jobs:
   build:
     needs: prepare
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     name: Build ${{ matrix.target }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/ha-china/HAOS-CN/security/code-scanning/1](https://github.com/ha-china/HAOS-CN/security/code-scanning/1)

Add an explicit `permissions` block to the `build` job in `.github/workflows/Builder.yml` so it no longer relies on inherited defaults.  
Best minimal safe fix (without changing current behavior) is to grant read access to repository contents, which satisfies the CodeQL recommendation and supports `actions/checkout`:

- File: `.github/workflows/Builder.yml`
- Region: under `build:` job definition (after `runs-on` is a clear placement)
- Add:
  - `permissions:`
  - `contents: read`

No imports, methods, or additional definitions are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Grant explicit contents: read permissions to the build job in the Builder workflow instead of relying on inherited defaults.