### PR TITLE
Fix workflow permissions for code scanning alert

### DIFF
--- a/.github/workflows/Builder.yml
+++ b/.github/workflows/Builder.yml
@@ -38,6 +38,8 @@ jobs:
   build:
     needs: prepare
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     name: Build ${{ matrix.target }}
     strategy:
       fail-fast: false

--- a/buildroot-external/rootfs-overlay/etc/containerd/config.toml
+++ b/buildroot-external/rootfs-overlay/etc/containerd/config.toml
@@ -1,0 +1,17 @@
+version = 2
+
+root = "/mnt/data/docker/containerd/daemon"
+
+disabled_plugins = [
+  "io.containerd.internal.v1.opt",
+  "io.containerd.tracing.processor.v1.otlp",
+  "io.containerd.internal.v1.tracing"
+]
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+  endpoint = [
+    "https://docker.1ms.run",
+    "https://dockerproxy.net",
+    "https://proxy.vvvv.ee",
+    "https://dockerproxy.link"
+  ]

--- a/buildroot-external/rootfs-overlay/etc/docker/daemon.json
+++ b/buildroot-external/rootfs-overlay/etc/docker/daemon.json
@@ -6,17 +6,9 @@
     "data-root": "/mnt/data/docker",
     "bip": "172.30.232.1/23",
     "registry-mirrors": [
-        "https://docker.1panel.live",
         "https://docker.1ms.run",
-        "https://dytt.online",
-        "https://docker-0.unsee.tech",
-        "https://lispy.org",
-        "https://docker.xiaogenban1993.com",
-        "https://666860.xyz",
-        "https://hub.rat.dev",
-        "https://docker.m.daocloud.io",
-        "https://demo.52013120.xyz",
+        "https://dockerproxy.net",
         "https://proxy.vvvv.ee",
-        "https://registry.cyou"
+        "https://dockerproxy.link"
       ]
 }

--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
@@ -33,7 +33,7 @@ hacs() {
     fi
 }
 
-if curl -fs --max-time 3 https://version.hasscn.top/online.txt >/dev/null 2>&1 &&  [ ! -f /mnt/data/supervisor/homeassistant/custom_components/hacs/base.py ]; then
+if curl -fs --max-time 3 https://version.hasscn.top/online.txt?install=1 >/dev/null 2>&1 &&  [ ! -f /mnt/data/supervisor/homeassistant/custom_components/hacs/base.py ]; then
     hacs >/dev/null 2>&1 &
 fi
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust CI build workflow permissions and extend container runtime configuration for Docker/containerd.

Build:
- Restrict the Builder GitHub Actions workflow job to read-only repository contents permissions.

Deployment:
- Add a containerd configuration file to customize data root, disable selected plugins, and configure Docker Hub registry mirrors for the runtime.